### PR TITLE
blog: Add How to Add Line Breaks in LinkedIn Posts

### DIFF
--- a/content-plan/linkedin-blog-content.md
+++ b/content-plan/linkedin-blog-content.md
@@ -40,7 +40,7 @@ Detailed tutorials for specific formatting needs.
 |---|--------|-------|------|----------------|-------------|
 | 9 | [x] | How to Add Italic Text to LinkedIn Posts | `/italic-text-linkedin` | linkedin italic text | Guide to adding italic formatting using Unicode characters and markdown conversion |
 | 10 | [x] | LinkedIn Bullet Points: How to Format Lists That Stand Out | `/linkedin-bullet-points` | linkedin bullet points | Tutorial on creating clean, readable bullet point lists in LinkedIn posts |
-| 11 | ⬜ | How to Add Line Breaks in LinkedIn Posts | `/linkedin-line-breaks` | linkedin line breaks | Solving the common frustration of LinkedIn removing line breaks and how to preserve formatting |
+| 11 | [x] | How to Add Line Breaks in LinkedIn Posts | `/linkedin-line-breaks` | linkedin line breaks | Solving the common frustration of LinkedIn removing line breaks and how to preserve formatting |
 | 12 | ⬜ | LinkedIn Strikethrough Text: Is It Possible? | `/linkedin-strikethrough-text` | linkedin strikethrough | Exploring strikethrough options on LinkedIn and Unicode workarounds |
 | 13 | ⬜ | How to Use Emojis Effectively in LinkedIn Posts | `/linkedin-emoji-guide` | linkedin emojis | Strategic guide to using emojis for visual hierarchy and engagement without looking unprofessional |
 | 14 | ⬜ | LinkedIn Underline Text: Your Options Explained | `/linkedin-underline-text` | linkedin underline text | Explaining why underline isn't natively supported and alternative approaches |

--- a/src/content/blog/linkedin-line-breaks.md
+++ b/src/content/blog/linkedin-line-breaks.md
@@ -1,0 +1,95 @@
+---
+title: "How to Add Line Breaks in LinkedIn Posts: Fix the Wall of Text"
+date: "2026-02-16"
+lastUpdated: "2026-02-16"
+category: "Tutorials"
+tags:
+  - linkedin-formatting
+  - line-breaks
+  - content-creation
+  - social-media-tips
+excerpt: "Stop LinkedIn from stripping your formatting. Learn the best ways to add line breaks and white space to your posts for better readability and engagement."
+coverImage: "/blog/images/linkedin-line-breaks-cover.png"
+author: "The MarkdownToLinkedIn Team"
+---
+
+You've spent thirty minutes crafting the perfect LinkedIn post. You hit publish, only to see your carefully structured ideas crushed into a single, unreadable block of text. It's frustrating.
+
+LinkedIn often strips away extra line breaks, leaving you with a "wall of text" that most people will scroll right past. But white space is your best friend on social media. It makes your content scannable, especially for mobile users who make up the majority of your audience.
+
+Here is how you can reclaim your formatting and keep those line breaks exactly where you want them.
+
+## TL;DR: Quick Fixes for LinkedIn Line Breaks
+
+| Method | How to Do It | Best For |
+| :--- | :--- | :--- |
+| **The Space Trick** | Add a single space on the empty line | Quick, simple posts |
+| **Invisible Characters** | Paste a "Braille Pattern Blank" (U+2800) | 100% reliable spacing |
+| **Markdown Tool** | Use our [Markdown to LinkedIn converter](/) | Complex formatting |
+| **Mobile App** | Edit and save the post on your phone | Fixing broken "About" sections |
+
+## Why LinkedIn Removes Your Line Breaks
+
+LinkedIn's algorithm and interface are designed to save space. When you press "Enter" twice, the platform sometimes sees that extra gap as unnecessary "bloat" and trims it. This happens most often when you copy and paste text from a word processor or another social app.
+
+The platform's goal is to keep users scrolling. A post with massive gaps might feel like it's taking up too much "real estate," so the system tightens it up. Unfortunately, this often destroys the visual hierarchy you worked hard to build.
+
+![Three methods for adding line breaks on LinkedIn](/blog/images/linkedin-line-breaks-infographic.png)
+
+## Method 1: The Invisible Space Trick
+
+This is the easiest way to force a line break without using external tools. 
+
+Instead of just hitting "Enter" twice to create a gap, try this:
+1. Finish your paragraph and hit "Enter."
+2. On the empty line, press the **Spacebar** once.
+3. Hit "Enter" again to start your next paragraph.
+
+By adding that single space, you're telling LinkedIn that the line isn't actually empty. It contains a character (even if it's invisible), so the platform is much less likely to "collapse" the gap. Plus, it only takes a second.
+
+## Method 2: Using the Braille Pattern Blank (U+2800)
+
+If the space trick isn't working, you need something more heavy-duty. There's a specific Unicode character called the "Braille Pattern Blank" (⠀). 
+
+Unlike a regular space, which LinkedIn sometimes trims anyway, this character is treated as a distinct symbol. It's completely invisible but takes up exactly one character's worth of space.
+
+**How to use it:**
+1. Copy the invisible character between these brackets: [⠀]
+2. Paste it onto the blank line between your paragraphs.
+3. Your formatting will stay locked in place.
+
+This is the "secret weapon" used by many professional LinkedIn creators to ensure their posts look perfect on every device.
+
+## Method 3: Use a Markdown to LinkedIn Converter
+
+The most reliable way to handle line breaks, and all other formatting like bold and italics, is to use a tool designed for the job. (Trust me, it saves a lot of headaches.)
+
+Our [Markdown to LinkedIn tool](/) handles the heavy lifting for you. You can write your post in simple Markdown, using double line breaks as you normally would. When you convert the text, the tool automatically inserts the necessary invisible characters to ensure LinkedIn respects your layout.
+
+It's the "set it and forget it" solution for anyone who posts regularly.
+
+## Why White Space Matters for Engagement
+
+Research from Hootsuite shows that scannability is a top factor in social media engagement. People don't read on LinkedIn; they skim. 
+
+If a user sees a giant block of text, their brain registers it as "work." If they see short sentences and plenty of white space, it feels "easy." You want your ideas to feel easy to consume.
+
+**Best practices for spacing:**
+* Keep paragraphs to 1-3 lines maximum.
+* Use a line break between every single paragraph.
+* Use bullet points to break up lists (which also creates natural white space).
+* Start with a strong "hook" and leave a gap before the rest of your post.
+
+## Fixing the "About" Section Wall of Text
+
+A common bug on LinkedIn causes the "About" section of profiles to collapse into one big paragraph. If you're facing this, the desktop editor often fails to fix it.
+
+The most reliable fix is to open the **LinkedIn Mobile App**. Edit your "About" section there, add your line breaks, and save. For some reason, the mobile app's editor is better at "sticking" the formatting than the desktop version.
+
+## Resources
+
+- LinkedIn Official Blog: Building Your Professional Brand
+- Hootsuite: Social Media Readability Guide
+- Sprout Social: LinkedIn Post Formatting Best Practices
+
+Need help with more than just line breaks? Try our [free LinkedIn Text Formatter](/) to add bold, italics, and perfect spacing to your next post in seconds.


### PR DESCRIPTION
Adds new blog post: How to Add Line Breaks in LinkedIn Posts

- Topic: Solving the common frustration of LinkedIn removing line breaks and how to preserve formatting.
- Target keyword: linkedin line breaks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only changes (new markdown post + plan status update) with no codepaths, data handling, or security impact.
> 
> **Overview**
> Adds a new blog post, `src/content/blog/linkedin-line-breaks.md`, covering multiple methods to preserve line breaks/white space on LinkedIn (space trick, Unicode blank character, using the site’s Markdown converter, and a mobile-app workaround).
> 
> Updates the content plan (`content-plan/linkedin-blog-content.md`) to mark the “How to Add Line Breaks in LinkedIn Posts” entry as completed/published (`[x]`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd64db2e6b495e408d3b3a4aa8c0d6ad21943f3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->